### PR TITLE
WebUI Services, fix edit, delete button on top of each other, generate more compact table

### DIFF
--- a/includes/html/pages/services.inc.php
+++ b/includes/html/pages/services.inc.php
@@ -190,7 +190,6 @@ require_once 'includes/html/modal/delete_service.inc.php';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_name'], [])) . '</td>';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_type'], [])) . '</td>';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_ip'], [])) . '</td>';
-
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_message'], [])) . '</td>';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_desc'], [])) . '</td>';
                         echo '<td>' . \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) . '</td>';


### PR DESCRIPTION
Fix edit, delete button on top of each other in Services page, after update to 22.2.0
generate a more compact table removing big empty space after last service of each device.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

Screenshot
Before:
![Services-before](https://user-images.githubusercontent.com/3173115/154590409-bf33c331-1368-4e97-9f08-6b12630a8952.png)

After:
![Services-After](https://user-images.githubusercontent.com/3173115/154590425-c82af9ac-df04-43e4-a4f2-ad0d7b0a4255.png)

